### PR TITLE
fix UnsupportedOperationException + documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,26 @@ The library adds the folowing steps to Jenkins pipeline dsl:
 - [__approveScripts__](https://github.com/SAP/jenkins-pipelayer/blob/master/USAGE.md#approve-scripts) => this step approves jobs generated from templates on jenkins
 - [__libToFs__](https://github.com/SAP/jenkins-pipelayer/blob/master/USAGE.md#host-shared-library-on-filesystem) => particularly useful to reduce the number of queries to github
 
-Have a look at [USAGE.md](https://github.com/SAP/jenkins-pipelayer/blob/master/USAGE.md) for a description of the steps introduced by Jenkins Pipelayer and a better explanation of the [template engine](https://github.com/SAP/jenkins-pipelayer/blob/master/USAGE.md#template-engine).
+Have a look at [USAGE.md](https://github.com/SAP/jenkins-pipelayer/blob/master/USAGE.md) for a description of the steps introduced by Jenkins Pipelayer.
+
+The template engines introduced by step `generateJobs` can create and manage jobs based on the same template parameterized by multiple property files.
+
+For instance, the following two property files would generate job1 and job2, where job 1 displays `example.com` and job2 displays `site.com`
+
+```
+// ./config/myjob1.properties
+hcp.host=example.com
+
+// ./config/myjob2.properties
+hcp.host=site.com
+
+// mytemplate.groovy
+    steps {
+            println "{{hcp.host}}"
+    }
+```
+
+see the usage documentation here for the [template engine](https://github.com/SAP/jenkins-pipelayer/blob/master/USAGE.md#template-engine)
 
 We made samples to help you understand how to use the library. Please check out the [sample](https://github.com/SAP/jenkins-pipelayer/tree/master/sample) folder
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -23,7 +23,7 @@ At first run of `generateJobs` step, approve the seed job.
 
 ### Generate jobs
 
-To generate jobs from jobs or templates configuration files, use `generateJobs`.
+To generate jobs from jobs or [templates configuration files](https://github.com/SAP/jenkins-pipelayer/blob/master/USAGE.md#template-engine), use `generateJobs`.
 
 Usage:
 

--- a/resources/com/sap/corydoras/script/setLibrary.groovy
+++ b/resources/com/sap/corydoras/script/setLibrary.groovy
@@ -11,7 +11,7 @@ def createIfMissing(String libName, String gitUrl, String defaultVersion) {
     lib.allowVersionOverride = true
 
     GlobalLibraries globalLibraries = GlobalLibraries.get()
-    List libs = globalLibraries.libraries
+    List libs = new ArrayList(globalLibraries.libraries)
 
     boolean exists = false
     for (LibraryConfiguration libConfig : libs) {
@@ -25,5 +25,6 @@ def createIfMissing(String libName, String gitUrl, String defaultVersion) {
         libs.add(lib)
         globalLibraries.setLibraries(libs)
         globalLibraries.save()
+        println 'Library ' + libName + ' added'
     }
 }


### PR DESCRIPTION
setLibrary.groovy could throw an error at line 25 `libs.add(lib)`,
if there was no library already set (which should not occur)

add documentation to configure the library quickly via jenkins console